### PR TITLE
Add flash attention

### DIFF
--- a/app/_interfaces/index.ts
+++ b/app/_interfaces/index.ts
@@ -32,6 +32,7 @@ export interface RunConfig {
   numGPUs: number
   isFSDP: boolean
   isInferenceModelParallelism: boolean
+  maskRate: number
 }
 
 export interface ResultEstimation {

--- a/app/_interfaces/index.ts
+++ b/app/_interfaces/index.ts
@@ -11,6 +11,11 @@ export enum Optimizer {
   SGD,
 }
 
+export enum AttentionType {
+  Vanilla,
+  Flash
+}
+
 export interface ModelConfig {
   numParams: number
   hiddenSize: number
@@ -19,6 +24,7 @@ export interface ModelConfig {
   numKeyValueHeads: number
   intermediateSize: number
   numLayers: number
+  attentionType?: AttentionType
 }
 
 export interface RunConfig {

--- a/app/_interfaces/index.ts
+++ b/app/_interfaces/index.ts
@@ -38,7 +38,6 @@ export interface RunConfig {
   numGPUs: number
   isFSDP: boolean
   isInferenceModelParallelism: boolean
-  maskRate: number
 }
 
 export interface ResultEstimation {

--- a/app/_lib/index.ts
+++ b/app/_lib/index.ts
@@ -25,6 +25,7 @@ export function estimateResult({
     inferencePrecision,
     isFSDP,
     isInferenceModelParallelism,
+    maskRate
   } = runConfig
 
   const bytesPerParam = isTraining
@@ -53,7 +54,7 @@ export function estimateResult({
 
   // On training storing probabilities after softmax
   // output which are the same size as output.
-  const outputs = 4 * batchSize * sequenceLength * vocabSize * (isTraining ? 2 : 1)
+  const outputs = 4 * batchSize * sequenceLength * vocabSize * (isTraining ? 2 : 1) * maskRate
 
   const gradients = (4 * numParams * 10 ** 9) / gpuDivisor
   const firstMoments = (4 * numParams * 10 ** 9) / gpuDivisor

--- a/app/_lib/index.ts
+++ b/app/_lib/index.ts
@@ -26,7 +26,6 @@ export function estimateResult({
     inferencePrecision,
     isFSDP,
     isInferenceModelParallelism,
-    maskRate
   } = runConfig
 
   const bytesPerParam = isTraining
@@ -55,7 +54,7 @@ export function estimateResult({
 
   // On training storing probabilities after softmax
   // output which are the same size as output.
-  const outputs = 4 * batchSize * sequenceLength * vocabSize * (isTraining ? 2 : 1) * maskRate
+  const outputs = 4 * batchSize * sequenceLength * vocabSize * (isTraining ? 2 : 1)
 
   const gradients = (4 * numParams * 10 ** 9) / gpuDivisor
   const firstMoments = (4 * numParams * 10 ** 9) / gpuDivisor

--- a/app/_lib/index.ts
+++ b/app/_lib/index.ts
@@ -1,5 +1,5 @@
 import { ModelConfig, Optimizer, Precision, ResultEstimation, RunConfig, Unit, AttentionType } from "@/app/_interfaces"
-import { log } from "console"
+
 
 export function estimateResult({
   modelConfig,

--- a/app/configurations.ts
+++ b/app/configurations.ts
@@ -11,26 +11,12 @@ export const defaultRunConfig: RunConfig = {
   numGPUs: 1,
   isFSDP: true,
   isInferenceModelParallelism: true,
-  maskRate: 0.30,
 }
 
 export const modelConfigPresets: {
   label: string
   modelConfig: ModelConfig
 }[] = [
-  {
-    label: "databio/atacformer-small",
-    modelConfig: {
-      numParams: 0.15,
-      numLayers: 6,
-      vocabSize: 100_000,
-      hiddenSize: 384,
-      intermediateSize: 1536,
-      numAttentionHeads: 8,
-      numKeyValueHeads: 8,
-      attentionType: AttentionType.Vanilla,
-    },
-  },
   {
     label: "NousResearch/Llama-2-70b-hf",
     modelConfig: {
@@ -41,6 +27,7 @@ export const modelConfigPresets: {
       intermediateSize: 28672,
       numAttentionHeads: 64,
       numKeyValueHeads: 8,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -53,6 +40,7 @@ export const modelConfigPresets: {
       intermediateSize: 13824,
       numAttentionHeads: 40,
       numKeyValueHeads: 40,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -65,6 +53,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 32,
       intermediateSize: 11008,
       numLayers: 32,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -77,6 +66,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 8,
       intermediateSize: 14336,
       numLayers: 32,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -89,6 +79,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 32,
       intermediateSize: 4 * 2560,
       numLayers: 32,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -101,6 +92,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 32,
       intermediateSize: 4 * 2048,
       numLayers: 24,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -113,6 +105,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 25,
       intermediateSize: 4 * 1600,
       numLayers: 48,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -125,6 +118,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 20,
       intermediateSize: 4 * 1280,
       numLayers: 36,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -137,6 +131,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 16,
       intermediateSize: 4 * 1024,
       numLayers: 24,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {
@@ -149,6 +144,7 @@ export const modelConfigPresets: {
       numKeyValueHeads: 12,
       intermediateSize: 4 * 768,
       numLayers: 12,
+      attentionType: AttentionType.Vanilla,
     },
   },
 ]

--- a/app/configurations.ts
+++ b/app/configurations.ts
@@ -1,4 +1,4 @@
-import { ModelConfig, Optimizer, Precision, RunConfig } from "@/app/_interfaces"
+import { ModelConfig, Optimizer, Precision, AttentionType, RunConfig } from "@/app/_interfaces"
 
 export const defaultRunConfig: RunConfig = {
   inferencePrecision: Precision.half,
@@ -28,6 +28,7 @@ export const modelConfigPresets: {
       intermediateSize: 1536,
       numAttentionHeads: 8,
       numKeyValueHeads: 8,
+      attentionType: AttentionType.Vanilla,
     },
   },
   {

--- a/app/configurations.ts
+++ b/app/configurations.ts
@@ -11,12 +11,25 @@ export const defaultRunConfig: RunConfig = {
   numGPUs: 1,
   isFSDP: true,
   isInferenceModelParallelism: true,
+  maskRate: 0.30,
 }
 
 export const modelConfigPresets: {
   label: string
   modelConfig: ModelConfig
 }[] = [
+  {
+    label: "databio/atacformer-small",
+    modelConfig: {
+      numParams: 0.15,
+      numLayers: 6,
+      vocabSize: 100_000,
+      hiddenSize: 384,
+      intermediateSize: 1536,
+      numAttentionHeads: 8,
+      numKeyValueHeads: 8,
+    },
+  },
   {
     label: "NousResearch/Llama-2-70b-hf",
     modelConfig: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -162,18 +162,31 @@ export default function App() {
                 helperText={runConfig.batchSize === 0 ? "Can't be empty!" : ""}
               />
             </Stack>
-
-            <TextField
-              label="Number of GPUs"
-              value={runConfig.numGPUs > 0 ? runConfig.numGPUs : ""}
-              error={runConfig.numGPUs === 0}
-              onChange={(e) =>
-                Number(e.target.value) >= 0
-                  ? setRunConfig({ ...runConfig, numGPUs: Number(e.target.value) })
-                  : runConfig.numGPUs
-              }
-              helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
-            />
+              
+            <Stack spacing={1} direction="row" alignItems="top" justifyContent="center">
+              <TextField
+                label="Number of GPUs"
+                value={runConfig.numGPUs > 0 ? runConfig.numGPUs : ""}
+                error={runConfig.numGPUs === 0}
+                onChange={(e) =>
+                  Number(e.target.value) >= 0
+                    ? setRunConfig({ ...runConfig, numGPUs: Number(e.target.value) })
+                    : runConfig.numGPUs
+                }
+                helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
+              />
+              <TextField
+                label="Mask rate"
+                value={runConfig.maskRate > 0 ? runConfig.maskRate : ""}
+                error={runConfig.maskRate === 0}
+                onChange={(e) =>
+                  Number(e.target.value) >= 0
+                    ? setRunConfig({ ...runConfig, maskRate: Number(e.target.value) })
+                    : runConfig.maskRate
+                }
+                helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
+              />
+            </Stack>
 
             {runConfig.isTraining && runConfig.numGPUs > 1 && (
               <Stack spacing={1} direction="row" alignItems="center" justifyContent="left">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import StackedBarChart from "@/app/_components/StackedBarChart"
-import { Optimizer, Precision, Unit } from "@/app/_interfaces"
+import { Optimizer, Precision, Unit, AttentionType } from "@/app/_interfaces"
 import { estimateResult, getTotalUsagePerGPU } from "@/app/_lib"
 import { defaultRunConfig, modelConfigPresets } from "@/app/configurations"
 import { HelpOutline } from "@mui/icons-material"
@@ -137,6 +137,22 @@ export default function App() {
               </Stack>
             )}
 
+            <Stack spacing={1} direction="row" alignItems="center" justifyContent="left">
+                <Typography variant="body1">Attention: </Typography>
+                <Chip
+                  label="Vanilla"
+                  color="primary"
+                  variant={modelConfig.attentionType == AttentionType.Vanilla ? "filled" : "outlined"}
+                  onClick={() => setModelConfig({ ...modelConfig, attentionType: AttentionType.Vanilla })}
+                />
+                <Chip
+                  label="Flash"
+                  color="primary"
+                  variant={modelConfig.attentionType == AttentionType.Flash ? "filled" : "outlined"}
+                  onClick={() => setModelConfig({ ...modelConfig, attentionType: AttentionType.Flash })}
+                />
+              </Stack>
+
             <Stack spacing={1} direction="row" alignItems="top" justifyContent="center">
               <TextField
                 label="Sequence Length"
@@ -185,6 +201,7 @@ export default function App() {
                     : runConfig.maskRate
                 }
                 helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
+                type="number"
               />
             </Stack>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -257,6 +257,7 @@ export default function App() {
                   : modelConfig.numParams
               }
               helperText={modelConfig.numParams === 0 ? "Can't be empty!" : ""}
+              type="number"
             />
 
             <Stack spacing={1} direction="row" alignItems="top" justifyContent="center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -178,33 +178,17 @@ export default function App() {
                 helperText={runConfig.batchSize === 0 ? "Can't be empty!" : ""}
               />
             </Stack>
-              
-            <Stack spacing={1} direction="row" alignItems="top" justifyContent="center">
-              <TextField
-                label="Number of GPUs"
-                value={runConfig.numGPUs > 0 ? runConfig.numGPUs : ""}
-                error={runConfig.numGPUs === 0}
-                onChange={(e) =>
-                  Number(e.target.value) >= 0
-                    ? setRunConfig({ ...runConfig, numGPUs: Number(e.target.value) })
-                    : runConfig.numGPUs
-                }
-                helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
-              />
-              <TextField
-                label="Mask rate"
-                value={runConfig.maskRate > 0 ? runConfig.maskRate : ""}
-                error={runConfig.maskRate === 0}
-                onChange={(e) =>
-                  Number(e.target.value) >= 0
-                    ? setRunConfig({ ...runConfig, maskRate: Number(e.target.value) })
-                    : runConfig.maskRate
-                }
-                helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
-                type="number"
-              />
-            </Stack>
-
+            <TextField
+              label="Number of GPUs"
+              value={runConfig.numGPUs > 0 ? runConfig.numGPUs : ""}
+              error={runConfig.numGPUs === 0}
+              onChange={(e) =>
+                Number(e.target.value) >= 0
+                  ? setRunConfig({ ...runConfig, numGPUs: Number(e.target.value) })
+                  : runConfig.numGPUs
+              }
+              helperText={runConfig.numGPUs === 0 ? "Can't be empty!" : ""}
+            />
             {runConfig.isTraining && runConfig.numGPUs > 1 && (
               <Stack spacing={1} direction="row" alignItems="center" justifyContent="left">
                 <FormControlLabel


### PR DESCRIPTION
Flash attention is now [built in](https://pytorch.org/blog/pytorch2-2/) to PyTorch. Its use in LLMs is becoming increasingly common. To that end, it would be useful to have the ability to calculate VRAM usage with FlashAttention over Vanilla self-attention. This was mentioned in #1 

I assumed that the space complexity was reduced from $O\left(n^2 \right)$ to $O\left( n \log n \right)$, based on [the original paper](https://arxiv.org/abs/2205.14135).

Vanilla is still the default, but users now have the option to select flashattn.

**note:** there are other commits, because i was originally forking this to work for **encoder** models (BERT-style), but saw there was additional need for FlashAttention, so I created a new branch and removed the encoder-only stuff, keeping FlashAttention.